### PR TITLE
Support cloning of ProductData Service

### DIFF
--- a/lib/Productsup/Service/ProductData.php
+++ b/lib/Productsup/Service/ProductData.php
@@ -77,8 +77,6 @@ class ProductData extends Service {
         if ($this->finished) {
             throw new Exceptions\ClientException('the current batch is already finished, please create a new instance');
         }
-
-        return clone $this;
     }
 
 

--- a/lib/Productsup/Service/ProductData.php
+++ b/lib/Productsup/Service/ProductData.php
@@ -173,6 +173,10 @@ class ProductData extends Service {
         if($this->disableDiscards) {
             throw new Exceptions\ClientException('discards were disabled, but tried to send anyway');
         }
+        if(!$this->didSubmit) {
+            throw new Exceptions\ClientException('no data submitted yet');
+        }
+
         $request = $this->getRequest();
         $request->method = Request::METHOD_POST;
         $request->url .= '/discard';


### PR DESCRIPTION
Allows object to be cloned under certain circumstances

Do not allow cloning when:
 - a batch id is generated
 - products are already added
 - data is already submitted
 - the process is finished

Moves batch id created to initial upload of the process