### PR TITLE
Disable compression for all, enable for product upload only

### DIFF
--- a/lib/Productsup/Http/Request.php
+++ b/lib/Productsup/Http/Request.php
@@ -17,7 +17,7 @@ class Request
 
     public $queryParams = array();
 
-    public $allowCompression = true;
+    public $allowCompression = false;
 
     private $_Client;
 

--- a/lib/Productsup/Service/ProductData.php
+++ b/lib/Productsup/Service/ProductData.php
@@ -254,6 +254,7 @@ class ProductData extends Service {
         $this->createBatchId();
         $this->didSubmit = true;
         $request = $this->getRequest();
+        $request->allowCompression = true;
         $request->method = Request::METHOD_POST;
         $request->url .= '/upload';
         $request->postBody = $this->_productData;


### PR DESCRIPTION
By default disable request payload compression and enable only for product upload. 