### PR TITLE
Add missing parameter automatic_import

### DIFF
--- a/examples/Service/ProductData.php
+++ b/examples/Service/ProductData.php
@@ -96,6 +96,13 @@ $ProductService->delete(array(
     )
 );
 
+/**
+ * Optional: Deactivate the automatic import and export process (thats enabled by default) so that you are responsible
+ * for triggering a process after the commit (and for determining the type more precisely).
+ * @see examples\service\Process.php
+ * @see https://api-docs.productsup.io/#committing
+ */
+//$ProductService->setAutomaticImportScheduling(false);
 
 /**
  * if you added all products, call commit to start the processing:

--- a/lib/Productsup/Service/ProductData.php
+++ b/lib/Productsup/Service/ProductData.php
@@ -19,6 +19,8 @@ class ProductData extends Service {
 
     /** @var string what kind of import is this? see constants for further information */
     private $importType = self::TYPE_FULL;
+    /** @ var bool Whether the automatic triggering of an import & export should be scheduled. */
+    private $automaticImport = true;
 
     /** @var bool mainly for debugging - if true, client does raise exceptions if tried to send discards anyway */
     private $disableDiscards = false;
@@ -138,6 +140,14 @@ class ProductData extends Service {
         $this->importType = $type;
     }
 
+    /**
+     * Set the behavior of automatically scheduling an import & export when a batch is completed. Default is true.
+     * @see https://api-docs.productsup.io/#committing
+     * @param bool $mode If false, neither import nor export will start automatic, but you have to trigger a process.
+     */
+    public function setAutomaticImportScheduling(bool $mode) {
+        $this->automaticImport = $mode;
+    }
 
     /**
      * send products to the api that were not sent yet,
@@ -155,7 +165,8 @@ class ProductData extends Service {
         $request = $this->getRequest();
         $request->method = Request::METHOD_POST;
         $request->postBody = array(
-            'type' => $this->importType
+            'type' => $this->importType,
+            'automatic_import' => $this->automaticImport
         );
         $request->url .= '/commit';
         $response = $this->getIoHandler()->executeRequest($request);


### PR DESCRIPTION
The API offers the possibility to choose whether a full process (import and export) should be scheduled automatically 20 minutes after a commit or whether you trigger a process yourself via the process endpoint (to be more specific of the type). See https://api-docs.productsup.io/#committing

This pull request adds the currently missing API parameter automatic_import to be able using this feature; the default behavior remains the same.

Viele Grüße / Best regards,
Kevin Hemker 
Entwicklung / Development • motoin.de
motoin GmbH • Rotter Bruch 26a • D-52068 Aachen