### PR TITLE
Add optional parameter batch_id to process

### DIFF
--- a/lib/Productsup/Platform/Process.php
+++ b/lib/Productsup/Platform/Process.php
@@ -8,6 +8,7 @@ use Productsup\Platform\Site\Reference;
 class Process extends DataModel {
     public $action;
     public $action_id;
+    public $batch_id;
     public $site_id;
 
     /**
@@ -35,6 +36,10 @@ class Process extends DataModel {
             'id' => $this->action_id,
             'action' => $this->action,
         );
+
+        if (!is_null($this->batch_id)) {
+            $data['batch_id'] = $this->batch_id;
+        }
 
         if ($full) {
             $data['site_id'] = $this->site_id;

--- a/lib/Productsup/Service/ProductData.php
+++ b/lib/Productsup/Service/ProductData.php
@@ -91,6 +91,19 @@ class ProductData extends Service {
         }
     }
 
+    /**
+     * Returns the current batch id.
+     *
+     * note:
+     * If none has been set, a new one will be created. This prevents logical issues if getBatchId() is called
+     * before commit().
+     * @return string current batch id
+     */
+    public function getBatchId() {
+        $this->createBatchId();
+        return $this->_batchId;
+    }
+
     public function disableDiscards() {
         $this->disableDiscards = true;
     }


### PR DESCRIPTION
This pull request adds the possibility to send the missing and optional parameter batch_id to a process (see https://api-docs.productsup.io/#post). This is recommended in conjunction with writing product data, in case automatic_import has been disabled (see https://api-docs.productsup.io/#committing).
Passing a "batch_id" will trigger the process once the batch's data is ready for an import (instead of immediately, which can lead to processing old data).
Default behavior remains the same.