### PR TITLE
DEV-19634: Add site stream datasource endpoint

### DIFF
--- a/examples/Service/Streams.php
+++ b/examples/Service/Streams.php
@@ -1,0 +1,29 @@
+<?php
+
+include __DIR__.'/../../vendor/autoload.php';
+
+/**
+ * Authentication
+ *
+ * You'll get the client id and secret at the plaform (API Access)
+ **/
+$Client = new Productsup\Client();
+$Client->id = 1234;
+$Client->secret = 'simsalabim';
+
+$StreamService = new Productsup\Service\Streams($Client);
+$Reference = new Productsup\Platform\Site\Reference();
+
+/**
+ * You have to specify the site the streams belong to.
+ * This is done by references to the site.
+ *
+ * In case you have a productsup site id, you can pass it like this:
+ **/
+$Reference->setKey($Reference::REFERENCE_SITE);
+$Reference->setValue(1); // Site ID
+$StreamService->setReference($Reference);
+
+$Streams = $StreamService->get();
+echo 'Get one site-stream by its id: '.PHP_EOL;
+print_r($Streams);

--- a/lib/Productsup/Platform/Stream.php
+++ b/lib/Productsup/Platform/Stream.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Productsup\Platform;
+
+class Stream extends DataModel {
+    public $id;
+    public $site_id;
+    public $description;
+    public $source;
+    public $import_type;
+    public $import_id;
+    public $status;
+    public $settings;
+    public $stream;
+}

--- a/lib/Productsup/Service/Streams.php
+++ b/lib/Productsup/Service/Streams.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Productsup\Service;
+use Productsup\Platform\DataModel;
+use Productsup\Platform\Site;
+use Productsup\Platform\Site\Reference;
+use Productsup\Platform\Stream;
+use Productsup\Http\Request;
+
+class Streams extends Service {
+    protected $serviceName = 'streams';
+    protected $parent = 'sites';
+
+    public function setSite(Site $site) {
+        $this->_parentIdentifier = $site->id;
+    }
+
+    /**
+     * @return DataModel|Stream
+     */
+    protected function getDataModel() {
+        return new Stream();
+    }
+
+    public function get($id = null,$action = null) {
+        $request = $this->getRequest();
+        $request->method = Request::METHOD_GET;
+        if(!empty($this->params)) {
+            $request->queryParams = $this->params;
+        }
+
+        if($id) {
+            $request->url .= '/'.$id;
+            if($action) {
+                $request->url .= '/'.$action;
+            }
+        }
+
+        $data = $this->executeRequest($request);
+
+        if (isset($data['success']) && array_key_exists('Sources', $data)) {
+            $data['Streams'] = $data['Sources'];
+            unset($data['Sources']);
+            return $data;
+        }
+
+        return false;
+    }
+
+
+    public function setReference(Reference $reference) {
+        $this->_parentIdentifier = (string)$reference;
+    }
+}


### PR DESCRIPTION
A new site/<SITE_ID>/streams endpoint has been added through this PR in order to support existing customers who are still using this Platform-API-Client to interact with platform-api.


The endpoint is : /platform/v2/sites/1/streams
An example script under `/examples/Service/Streams.php` has been added to examples directory to make it easy to understand on it's usage.


Acceptance Criteria:
- [x] Update of PHP client not required
- [x] Site-Streams endpoint implemented in Platform API client
- [x] Platform API client documentation updated to reflect maintenance status
- [ ] Communication prepared for customer about the decision